### PR TITLE
Fix to/from manifest for params

### DIFF
--- a/lib/class_def_ast.js
+++ b/lib/class_def_ast.js
@@ -15,6 +15,7 @@ const assert = require('assert');
 const Ast = require('./ast');
 const Type = require('./type');
 const { prettyprintType, prettyprintValue, prettyprintJson, prettyprintClassDef } = require('./prettyprint');
+const { clean } = require('./utils');
 
 // Class and function definitions
 
@@ -340,6 +341,33 @@ class FunctionDef extends ExpressionSignature {
 }
 module.exports.FunctionDef = FunctionDef;
 
+function htmlTypeToTT(htmlType) {
+    switch (htmlType) {
+    case 'text':
+        return Type.String;
+    case 'password':
+        return Type.Entity('tt:password');
+    case 'number':
+        return Type.Number;
+    case 'url':
+        return Type.Entity('tt:url');
+    default:
+        throw new Error(`Can't handle HTML input type ${htmlType}`);//'
+    }
+}
+function typeToHTML(type) {
+    if (type.isString)
+        return 'text';
+    else if (type.isNumber)
+        return 'number';
+    else if (type.isEntity && type.type === 'tt:password')
+        return 'password';
+    else if (type.isEntity && type.type === 'tt:url')
+        return 'url';
+    else
+        throw new Error(`Can't convert type ${type} to HTML`);//'
+}
+
 class ClassDef {
     constructor(kind, _extends, queries, actions, imports, metadata, annotations) {
         this.name = kind;
@@ -384,19 +412,17 @@ class ClassDef {
 
     _params() {
         let params = {};
-        if (this.config) {
-            switch (this.config.module) {
-                case 'org.thingpedia.config.form':
-                case 'org.thingpedia.config.basic_auth': {
-                    let argMap = this.config.in_params[0].value;
-                    Object.entries(argMap.value).forEach(([name, type]) => {
-                        if (Array.isArray(type))
-                            params[name] = type;
-                        else
-                            params[name] = prettyprintType(type);
-                    });
-                }
-            }
+        const config = this.config;
+        if (!config)
+            return params;
+        switch (config.module) {
+        case 'org.thingpedia.config.form':
+        case 'org.thingpedia.config.basic_auth': {
+            let argMap = config.in_params[0].value;
+            Object.entries(argMap.value).forEach(([name, type]) => {
+                params[name] = [clean(name), typeToHTML(type)];
+            });
+        }
         }
         return params;
     }
@@ -404,12 +430,12 @@ class ClassDef {
     _auth() {
         let auth = {};
         this.config.in_params.forEach((param) => {
+            if (param.value.isArgMap)
+                return;
             if (param.name === 'protocol')
-                auth['discoveryType'] = param.value.value;
-            else if (param.value.isString)
-                auth[param.name] = getString(param.value);
+                auth['discoveryType'] = param.value.toJS();
             else
-                auth[param.name] = param.value;
+                auth[param.name] = param.value.toJS();
         });
         if (this.config) {
             switch (this.config.module) {
@@ -498,9 +524,10 @@ class ClassDef {
 
         imports.push(new ImportStmt.Mixin(['loader'], manifest.module_type, []));
         let argmap = {};
-        Object.entries(manifest.params).forEach(([param, type]) => {
-            argmap[param] = type;
-        });
+        for (let param in manifest.params) {
+            const [, htmlType] = manifest.params[param];
+            argmap[param] = htmlTypeToTT(htmlType);
+        }
         argmap = new Ast.Value.ArgMap(argmap);
         if (manifest.auth) {
             let params = [];


### PR DESCRIPTION
Params in manifest are extremely legacy (they predate even having
triggers and actions in the manifest), and for that reason they
use HTML types rather than ThingTalk types.
Make sure that the conversion proceeds correctly.