### PR TITLE
Split discovery mixin into two, one for upnp and one for bluetooth

### DIFF
--- a/lib/class_def_ast.js
+++ b/lib/class_def_ast.js
@@ -519,7 +519,7 @@ class ClassDef {
                 for (let uuid of param.value.toJS())
                     extraKinds.push('bluetooth-uuid-' + uuid.toLowerCase());
                 break;
-            case 'st':
+            case 'search_target':
                 for (let st of param.value.toJS())
                     extraKinds.push('upnp-' + st.toLowerCase().replace(/^urn:/, '').replace(/:/g, '-'));
                 break;
@@ -665,14 +665,14 @@ class ClassDef {
                 imports.push(new ImportStmt.Mixin(['config'], 'org.thingpedia.config.none', params));
             }
         }
-        let uuids = [], upnpst = [], bluetoothclass = undefined;
+        let uuids = [], upnpSearchTarget = [], bluetoothclass = undefined;
         for (let type of (manifest.types || [])) {
             if (type.startsWith('bluetooth-uuid-'))
                 uuids.push(type.substring('bluetooth-uuid-'.length));
             else if (type.startsWith('bluetooth-class-'))
                 bluetoothclass = type.substring('bluetooth-class-'.length);
             else if (type.startsWith('upnp-'))
-                upnpst.push('urn:' + type.substring('upnp-'.length));
+                upnpSearchTarget.push('urn:' + type.substring('upnp-'.length));
         }
         const config = imports.find((i) => i.facets.includes('config'));
         switch (config.module) {
@@ -682,7 +682,7 @@ class ClassDef {
                 config.in_params.push(Ast.InputParam('device_class', Ast.Value.fromJS(Type.Enum(null), bluetoothclass)));
             break;
         case 'org.thingpedia.config.discovery.upnp':
-            config.in_params.push(Ast.InputParam('st', Ast.Value.fromJS(Type.Array(Type.String), upnpst)));
+            config.in_params.push(Ast.InputParam('search_target', Ast.Value.fromJS(Type.Array(Type.String), upnpSearchTarget)));
             break;
         }
 

--- a/lib/class_def_ast.js
+++ b/lib/class_def_ast.js
@@ -505,39 +505,57 @@ class ClassDef {
 
     _auth() {
         let auth = {};
-        this.config.in_params.forEach((param) => {
+        let extraKinds = [];
+
+        const config = this.config;
+        config.in_params.forEach((param) => {
             if (param.value.isArgMap)
                 return;
-            if (param.name === 'protocol')
-                auth['discoveryType'] = param.value.toJS();
-            else
+            switch (param.name) {
+            case 'device_class':
+                extraKinds.push('bluetooth-class-' + param.value.toJS());
+                break;
+            case 'uuids':
+                for (let uuid of param.value.toJS())
+                    extraKinds.push('bluetooth-uuid-' + uuid.toLowerCase());
+                break;
+            case 'st':
+                for (let st of param.value.toJS())
+                    extraKinds.push('upnp-' + st.toLowerCase().replace(/^urn:/, '').replace(/:/g, '-'));
+                break;
+
+            default:
                 auth[param.name] = param.value.toJS();
-        });
-        if (this.config) {
-            switch (this.config.module) {
-                case 'org.thingpedia.config.oauth2':
-                    auth.type = 'oauth2';
-                    break;
-                case 'org.thingpedia.config.custom_oauth':
-                    auth.type = 'custom_oauth';
-                    break;
-                case 'org.thingpedia.config.basic_auth':
-                    auth.type = 'basic';
-                    break;
-                case 'org.thingpedia.config.discovery':
-                    auth.type = 'discovery';
-                    break;
-                case 'org.thingpedia.config.interactive':
-                    auth.type = 'interactive';
-                    break;
-                case 'org.thingpedia.config.builtin':
-                    auth.type = 'builtin';
-                    break;
-                default:
-                    auth.type = 'none';
             }
+        });
+        switch (config.module) {
+        case 'org.thingpedia.config.oauth2':
+            auth.type = 'oauth2';
+            break;
+        case 'org.thingpedia.config.custom_oauth':
+            auth.type = 'custom_oauth';
+            break;
+        case 'org.thingpedia.config.basic_auth':
+            auth.type = 'basic';
+            break;
+        case 'org.thingpedia.config.discovery.bluetooth':
+            auth.type = 'discovery';
+            auth.discoveryType = 'bluetooth';
+            break;
+        case 'org.thingpedia.config.discovery.upnp':
+            auth.type = 'discovery';
+            auth.discoveryType = 'upnp';
+            break;
+        case 'org.thingpedia.config.interactive':
+            auth.type = 'interactive';
+            break;
+        case 'org.thingpedia.config.builtin':
+            auth.type = 'builtin';
+            break;
+        default:
+            auth.type = 'none';
         }
-        return auth;
+        return [auth, extraKinds];
     }
 
     _getCategory() {
@@ -548,13 +566,14 @@ class ClassDef {
             return 'data';
 
         switch (config.module) {
-            case 'org.thingpedia.config.builtin':
-            case 'org.thingpedia.config.none':
-                return 'data';
-            case 'org.thingpedia.config.discovery':
-                return 'physical';
-            default:
-                return 'online';
+        case 'org.thingpedia.config.builtin':
+        case 'org.thingpedia.config.none':
+            return 'data';
+        case 'org.thingpedia.config.discovery.bluetooth':
+        case 'org.thingpedia.config.discovery.upnp':
+            return 'physical';
+        default:
+            return 'online';
         }
     }
 
@@ -562,15 +581,17 @@ class ClassDef {
         let [queries, actions] = [{}, {}];
         Object.entries(this.queries).forEach(([name, query]) => queries[name] = query.toManifest());
         Object.entries(this.actions).forEach(([name, action]) => actions[name] = action.toManifest());
+
+        let [auth, extraKinds] = this._auth();
         let manifest = {
             module_type: this.loader ? this.loader.module : 'org.thingpedia.v2',
             kind: this.kind,
             params: this._params(),
-            auth: this._auth(),
+            auth: auth,
             queries,
             actions,
             version: this.annotations.version ? this.annotations.version.value : undefined,
-            types: this.extends || [],
+            types: (this.extends || []).concat(extraKinds),
             child_types: this.annotations.child_types ? this.annotations.child_types.value.map((v) => getString(v)) : [],
             category: this._getCategory()
         };
@@ -580,7 +601,7 @@ class ClassDef {
     }
 
     static fromManifest(kind, manifest) {
-        let _extends = manifest.types || [];
+        let _extends = (manifest.types || []).filter((t) => !t.startsWith('bluetooth-') && !t.startsWith('upnp-'));
         let imports = [];
         let queries = {};
         let actions = {};
@@ -608,46 +629,63 @@ class ClassDef {
         if (manifest.auth) {
             let params = [];
             Object.entries(manifest.auth).forEach(([param, value]) => {
-                if (param === 'discoveryType') {
-                    param = 'protocol';
-                    value = new Ast.Value.Enum(value);
-                }
-                if (param !== 'type') {
-                    if (typeof value === 'string')
-                        value = Ast.Value.String(value);
-                    params.push(new Ast.InputParam(param, value));
-                }
+                if (param === 'discoveryType' || param === 'type')
+                    return;
+                if (typeof value === 'string')
+                    value = Ast.Value.String(value);
+                params.push(new Ast.InputParam(param, value));
             });
             switch (manifest.auth.type) {
-                case 'oauth2':
-                case 'custom_oauth':
-                    imports.push(new ImportStmt.Mixin(['config'], 'org.thingpedia.config.' + manifest.auth.type, params));
+            case 'oauth2':
+            case 'custom_oauth':
+                imports.push(new ImportStmt.Mixin(['config'], 'org.thingpedia.config.' + manifest.auth.type, params));
+                break;
+            case 'interactive':
+                imports.push(new ImportStmt.Mixin(['config'], 'org.thingpedia.config.interactive', params));
+                break;
+            case 'discovery':
+                imports.push(new ImportStmt.Mixin(['config'], 'org.thingpedia.config.discovery.' + manifest.auth.discoveryType, params));
+                break;
+            case 'basic':
+                if (!(params.some((param) => param.name === 'extra_params')))
+                    params.push(new Ast.InputParam('extra_params', argmap));
+                imports.push(new ImportStmt.Mixin(['config'], 'org.thingpedia.config.basic_auth', params));
+                break;
+            case 'builtin':
+                imports.push(new ImportStmt.Mixin(['config'], 'org.thingpedia.config.builtin', params));
+                break;
+            case 'none':
+                if (Object.keys(manifest.params).length > 0) {
+                    if (!(params.some((param) => param.name === 'params')))
+                        params.push(new Ast.InputParam('params', argmap));
+                    imports.push(new ImportStmt.Mixin(['config'], 'org.thingpedia.config.form', params));
                     break;
-                case 'interactive':
-                    imports.push(new ImportStmt.Mixin(['config'], 'org.thingpedia.config.interactive', params));
-                    break;
-                case 'discovery':
-                    imports.push(new ImportStmt.Mixin(['config'], 'org.thingpedia.config.discovery', params));
-                    break;
-                case 'basic':
-                    if (!(params.some((param) => param.name === 'extra_params')))
-                        params.push(new Ast.InputParam('extra_params', argmap));
-                    imports.push(new ImportStmt.Mixin(['config'], 'org.thingpedia.config.basic_auth', params));
-                    break;
-                case 'builtin':
-                    imports.push(new ImportStmt.Mixin(['config'], 'org.thingpedia.config.builtin', params));
-                    break;
-                case 'none':
-                    if (Object.keys(manifest.params).length > 0) {
-                        if (!(params.some((param) => param.name === 'params')))
-                            params.push(new Ast.InputParam('params', argmap));
-                        imports.push(new ImportStmt.Mixin(['config'], 'org.thingpedia.config.form', params));
-                        break;
-                    }
-                default:
-                    imports.push(new ImportStmt.Mixin(['config'], 'org.thingpedia.config.none', params));
+                }
+            default:
+                imports.push(new ImportStmt.Mixin(['config'], 'org.thingpedia.config.none', params));
             }
         }
+        let uuids = [], upnpst = [], bluetoothclass = undefined;
+        for (let type of (manifest.types || [])) {
+            if (type.startsWith('bluetooth-uuid-'))
+                uuids.push(type.substring('bluetooth-uuid-'.length));
+            else if (type.startsWith('bluetooth-class-'))
+                bluetoothclass = type.substring('bluetooth-class-'.length);
+            else if (type.startsWith('upnp-'))
+                upnpst.push('urn:' + type.substring('upnp-'.length));
+        }
+        const config = imports.find((i) => i.facets.includes('config'));
+        switch (config.module) {
+        case 'org.thingpedia.config.discovery.bluetooth':
+            config.in_params.push(Ast.InputParam('uuids', Ast.Value.fromJS(Type.Array(Type.String), uuids)));
+            if (bluetoothclass)
+                config.in_params.push(Ast.InputParam('device_class', Ast.Value.fromJS(Type.Enum(null), bluetoothclass)));
+            break;
+        case 'org.thingpedia.config.discovery.upnp':
+            config.in_params.push(Ast.InputParam('st', Ast.Value.fromJS(Type.Array(Type.String), upnpst)));
+            break;
+        }
+
         return new ClassDef(kind, _extends, queries, actions, imports, metadata, annotations);
     }
 }

--- a/lib/type.js
+++ b/lib/type.js
@@ -143,6 +143,8 @@ module.exports.isAssignable = function isAssignable(type, assignableTo, typeScop
         typeScope[assignableTo.elem] = type.elem;
         return true;
     }
+    if (type.isArray && assignableTo.isArray && type.elem.isAny)
+        return true;
     if (type.isArray && assignableTo.isEntity && assignableTo.type === 'tt:contact_group')
         return isAssignable(type.elem, Type.Entity('tt:contact'), typeScope, lenient);
     if (type.isDate && assignableTo.isTime)

--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -384,8 +384,10 @@ function typeCheckInputArgs(ast, schema, scope, classes, isMeta = false) {
         let inParamType = schema.getArgType(inParam.name);
         if (!inParamType || !schema.isArgInput(inParam.name))
             throw new TypeError('Invalid input parameter ' + inParam.name);
-        if (!Type.isAssignable(typeForValue(inParam.value, scope), inParamType, {}, true))
-            throw new TypeError('Invalid type for parameter '+ inParam.name);
+
+        const valueType = typeForValue(inParam.value, scope);
+        if (!Type.isAssignable(valueType, inParamType, {}, true))
+            throw new TypeError(`Invalid type for parameter ${inParam.name}, have ${valueType}, need ${inParamType}`);
         if (presentParams.has(inParam.name))
             throw new TypeError('Duplicate input param ' + inParam.name);
         presentParams.add(inParam.name);
@@ -640,9 +642,10 @@ function typeCheckMixin(import_stmt, mixin) {
         let i = mixin.args.indexOf(name);
         if (i === -1 || !mixin.is_input[i])
             throw new TypeError(`Invalid parameter ${name} for mixin ${mixin.kind}`);
-        let type = mixin.types[i];
-        if (!Type.isAssignable(typeForValue(value), type))
-            throw new TypeError(`Invalid type for parameter ${name}`);
+        let inParamType = mixin.types[i];
+        const valueType = typeForValue(value, {});
+        if (!Type.isAssignable(valueType, inParamType, {}, true))
+            throw new TypeError(`Invalid type for parameter ${name}, have ${valueType}, need ${inParamType}`);
         if (presentParams.has(name))
             throw new TypeError(`Duplicate input parameter ${name}`);
         presentParams.add(name);

--- a/test/mixins.json
+++ b/test/mixins.json
@@ -32,7 +32,7 @@
       ]
     },
     {
-      "kind": "org.thingpedia.generic_rest",
+      "kind": "org.thingpedia.generic_rest.v1",
       "args": [],
       "types": [],
       "required": [],
@@ -48,9 +48,17 @@
       "facets": [ "config" ]
     },
     {
-      "kind": "org.thingpedia.config.discovery",
-      "args": [ "protocol" ],
-      "types": [ "Enum(bluetooth, upnp)" ],
+      "kind": "org.thingpedia.config.discovery.bluetooth",
+      "args": [ "uuids", "device_class" ],
+      "types": [ "Array(String)", "Enum(audio_video,computer,health,imaging,misc,networking,peripheral,phone,toy,wearable)" ],
+      "required": [ true, false ],
+      "is_input": [ true, true ],
+      "facets": [ "config" ]
+    },
+    {
+      "kind": "org.thingpedia.config.discovery.upnp",
+      "args": [ "st" ],
+      "types": [ "Array(String)" ],
       "required": [ true ],
       "is_input": [ true ],
       "facets": [ "config" ]

--- a/test/mixins.json
+++ b/test/mixins.json
@@ -57,7 +57,7 @@
     },
     {
       "kind": "org.thingpedia.config.discovery.upnp",
-      "args": [ "st" ],
+      "args": [ "search_target" ],
       "types": [ "Array(String)" ],
       "required": [ true ],
       "is_input": [ true ],

--- a/test/sample.apps
+++ b/test/sample.apps
@@ -540,7 +540,7 @@ now => @com.twitter.follow(user_name=null^^tt:username("donald trump"));
 {
   class @com.foo {
     import loader from @org.thingpedia.v2();
-    import config from @org.thingpedia.config.discovery(protocol=enum(bluetooth));
+    import config from @org.thingpedia.config.discovery.bluetooth(uuids=[]);
 
     monitorable query get_power(out power : Enum(on, off))
     #_[canonical='power status of foo']
@@ -639,7 +639,7 @@ now => @com.twitter.follow(user_name=null^^tt:username("donald trump"));
 // Mixins 2
 {
   class @com.foo {
-    import loader from @org.thingpedia.generic_rest();
+    import loader from @org.thingpedia.generic_rest.v1();
     import config from @org.thingpedia.config.oauth2(client_id="xxx", client_secret="yyy");
   }
 }
@@ -670,7 +670,7 @@ now => @com.twitter.follow(user_name=null^^tt:username("donald trump"));
 // missing required parameter for mixin
 {
   class @com.foo {
-    import loader from @org.thingpedia.config.discovery();
+    import loader from @org.thingpedia.config.discovery.bluetooth();
   }
 }
 
@@ -778,7 +778,7 @@ dataset @foo {
 // ** typecheck: expect TypeError **
 // duplicate import
 class @com.foo {
-    import loader from @org.thingpedia.config.discovery(protocol=enum(bluetooth));
+    import loader from @org.thingpedia.config.discovery.bluetooth(uuids=["foo"]);
     import loader from @org.thingpedia.config.form(params=makeArgMap(url:String));
 }
 
@@ -894,7 +894,7 @@ abstract class @com.foo {
 // ** typecheck: expect TypeError **
 // no loader or config for abstract class
 abstract class @com.foo {
-  import loader from @org.thingpedia.config.discovery(protocol=enum(bluetooth));
+  import loader from @org.thingpedia.config.none();
   list query foo(out foo : String,
                  out bar : String);
 }

--- a/test/test_class_to_manifest.js
+++ b/test/test_class_to_manifest.js
@@ -203,7 +203,7 @@ const TEST_CASES = [
 
     'class @com.lg.tv.webos2 {\n' +
     '  import loader from @org.thingpedia.v2();\n' +
-    '  import config from @org.thingpedia.config.discovery.upnp(st=["urn:lge-com-service-webos-second-screen-1"]);\n' +
+    '  import config from @org.thingpedia.config.discovery.upnp(search_target=["urn:lge-com-service-webos-second-screen-1"]);\n' +
     '}\n',
 
     {

--- a/test/test_class_to_manifest.js
+++ b/test/test_class_to_manifest.js
@@ -56,11 +56,6 @@ const TEST_CASES = [
 
     'class @com.foo {\n' +
     '  import loader from @org.thingpedia.v2();\n' +
-    '  import config from @org.thingpedia.config.discovery(protocol=enum(bluetooth));\n' +
-    '}\n',
-
-    'class @com.foo {\n' +
-    '  import loader from @org.thingpedia.v2();\n' +
     '  import config from @org.thingpedia.config.interactive();\n' +
     '}\n',
 
@@ -160,7 +155,73 @@ const TEST_CASES = [
       },
       actions: {},
       version: 0
-    }
+    },
+
+    'class @org.thingpedia.bluetooth.speaker.a2dp {\n' +
+    '  import loader from @org.thingpedia.v2();\n' +
+    '  import config from @org.thingpedia.config.discovery.bluetooth(uuids=["0000110b-0000-1000-8000-00805f9b34fb"]);\n' +
+    '}\n',
+
+    {
+      kind: 'org.thingpedia.bluetooth.speaker.a2dp',
+      module_type: 'org.thingpedia.v2',
+      types: ['bluetooth-uuid-0000110b-0000-1000-8000-00805f9b34fb'],
+      child_types: [],
+      category: 'physical',
+      params: {
+      },
+      auth: {
+        type: 'discovery',
+        discoveryType: 'bluetooth'
+      },
+      queries: {},
+      actions: {},
+      version: 0
+    },
+
+    'class @org.thingpedia.bluetooth.foo {\n' +
+    '  import loader from @org.thingpedia.v2();\n' +
+    '  import config from @org.thingpedia.config.discovery.bluetooth(uuids=[], device_class=enum(computer));\n' +
+    '}\n',
+
+    {
+      kind: 'org.thingpedia.bluetooth.foo',
+      module_type: 'org.thingpedia.v2',
+      types: ['bluetooth-class-computer'],
+      child_types: [],
+      category: 'physical',
+      params: {
+      },
+      auth: {
+        type: 'discovery',
+        discoveryType: 'bluetooth'
+      },
+      queries: {},
+      actions: {},
+      version: 0
+    },
+
+    'class @com.lg.tv.webos2 {\n' +
+    '  import loader from @org.thingpedia.v2();\n' +
+    '  import config from @org.thingpedia.config.discovery.upnp(st=["urn:lge-com-service-webos-second-screen-1"]);\n' +
+    '}\n',
+
+    {
+      kind: 'com.lg.tv.webos2',
+      module_type: 'org.thingpedia.v2',
+      types: ['upnp-lge-com-service-webos-second-screen-1'],
+      child_types: [],
+      category: 'physical',
+      params: {
+      },
+      auth: {
+        type: 'discovery',
+        discoveryType: 'upnp'
+      },
+      queries: {},
+      actions: {},
+      version: 0
+    },
 ];
 
 async function test(i) {
@@ -169,9 +230,9 @@ async function test(i) {
 
     try {
         if (typeof tt === 'string') {
-            const meta = await Grammar.parseAndTypecheck(tt, schemaRetriever, true);
+            const meta = await Grammar.parseAndTypecheck(tt, schemaRetriever, false);
             let manifest_from_tt = toManifest(meta);
-            let generated = prettyprint(fromManifest('com.foo', manifest_from_tt));
+            let generated = prettyprint(fromManifest(meta.classes[0].kind, manifest_from_tt));
             if (tt !== generated) {
                 console.error('Test Case #' + (i+1) + ': does not match what expected');
                 console.error('Expected: ' + tt);
@@ -179,6 +240,7 @@ async function test(i) {
             }
         } else {
             const tt_from_manifest = fromManifest(tt.kind, tt);
+            await Grammar.parseAndTypecheck(tt_from_manifest.prettyprint(), schemaRetriever, false);
             const generated = toManifest(tt_from_manifest);
             generated.kind = tt.kind;
             assert.deepStrictEqual(generated, tt);


### PR DESCRIPTION
And migrate away from (ab)using types to mark discovery protocol
identifiers.
Instead, use mixin-specific parameter names and types.