### PR TITLE
Add versioning info to the API

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,8 @@ Ast.toManifest = toManifest;
 const builtin = require('./lib/builtin');
 
 module.exports = {
+    version: '1.2.0',
+
     // AST definitions
     Ast,
     Type,

--- a/test/test_all.js
+++ b/test/test_all.js
@@ -15,6 +15,7 @@ async function seq(array) {
 }
 
 seq([
+    ('./test_version'),
     ('./test_units'),
     ('./test_date_utils'),
     ('./test_builtin_values'),

--- a/test/test_version.js
+++ b/test/test_version.js
@@ -1,0 +1,22 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of ThingTalk
+//
+// Copyright 2018 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See COPYING for details
+"use strict";
+
+const assert = require('assert');
+
+const ThingTalk = require('..');
+const packageJson = require('../package.json');
+
+function main() {
+    assert.deepStrictEqual(ThingTalk.version, packageJson.version);
+}
+module.exports = main;
+if (!module.parent)
+    main();


### PR DESCRIPTION
Use ThingTalk.version to learn the version of the library

This commit duplicates the info from package.json to index.js,
as otherwise we have to load the whole package.json (using require
to be browserify compatible), which is a waste of memory to keep
for just 3 bytes.
A test ensures that the two places don't go out of sync.