### PR TITLE
Add formatting support for aggregations

### DIFF
--- a/lib/runtime/exec_environment.js
+++ b/lib/runtime/exec_environment.js
@@ -12,8 +12,8 @@
 const Formatter = require('./formatter');
 
 module.exports = class ExecEnvironment {
-    constructor(locale, timezone, schemaRetriever) {
-        this.format = new Formatter(locale, timezone, schemaRetriever);
+    constructor(locale, timezone, schemaRetriever, gettext) {
+        this.format = new Formatter(locale, timezone, schemaRetriever, gettext);
         this._scope = {};
     }
 

--- a/lib/runtime/formatter.js
+++ b/lib/runtime/formatter.js
@@ -19,9 +19,13 @@ function compileCode(code) {
 }
 
 module.exports = class Formatter extends FormatUtils {
-    constructor(locale, timezone, schemaRetriever) {
+    constructor(locale, timezone, schemaRetriever, gettext) {
         super(locale, timezone);
         this._schemas = schemaRetriever;
+        if (gettext)
+            this._ = gettext.dgettext.bind(gettext, 'thingtalk');
+        else
+            this._ = (x) => x;
     }
 
     _displayValue(value, opt) {
@@ -73,23 +77,40 @@ module.exports = class Formatter extends FormatUtils {
         });
     }
 
-    _formatKey(key) {
-        if (key.startsWith('__')) {
-            let agg = key.split('_')[2];
-            let field = key.substring(agg.length + 3);
-            return `${agg}${field === 'star'? '' : ` of ${field}`}`; //` <- fix GtkSourceView screwup
-        } else {
-            return key;
-        }
-    }
-
     _formatFallback(outputValue) {
         return Object.keys(outputValue).map((key) => {
             return `${clean(key)}: ${this._displayValue(outputValue[key])}`;
         });
     }
 
-    formatForType(outputType, outputValue, hint) {
+    _formatAggregation(outputValue, operator, outputType) {
+        if (operator === 'count' && outputValue.hasOwnProperty('count'))
+            return [this._("I found %d results.").format(outputValue.count)];
+
+        let key = Object.keys(outputValue)[0];
+
+        switch (operator) {
+        case 'count':
+            return [this._("I found %d distinct values of %s.").format(outputValue[key], clean(key))];
+
+        case 'min':
+            return [this._("The minimum %s is %s.").format(clean(key), this._displayValue(outputValue[key]))];
+
+        case 'max':
+            return [this._("The maximum %s is %s.").format(clean(key), this._displayValue(outputValue[key]))];
+
+        case 'avg':
+            return [this._("The average %s is %s.").format(clean(key), this._displayValue(outputValue[key]))];
+
+        case 'sum':
+            return [this._("The total %s is %s.").format(clean(key), this._displayValue(outputValue[key]))];
+
+        default:
+            throw new TypeError(`Unexpected aggregation operator ${operator}`);
+        }
+    }
+
+    async formatForType(outputType, outputValue, hint) {
         // apply masquerading for @remote.receive
         // outputValue[0..2] are the input parameters (principal, programId and flow)
         // outputValue[3] is the real underlying output type, and outputValue.slice(4)
@@ -101,6 +122,7 @@ module.exports = class Formatter extends FormatUtils {
         if (outputType === 'org.thingpedia.builtin.thingengine.builtin:get_commands')
             return { type: 'program', program: outputValue.program };
 
+
         if (outputType === null)
             return this._formatFallback(outputValue);
 
@@ -109,6 +131,10 @@ module.exports = class Formatter extends FormatUtils {
             let types = outputType.split('+');
             outputType = types[types.length-1];
         }
+
+        const aggregation = /^([a-zA-Z]+)\(([^)]+)\)$/.exec(outputType);
+        if (aggregation !== null)
+            return this._formatAggregation(outputValue, aggregation[1], aggregation[2]);
 
         let [kind, function_name] = outputType.split(':');
         return this._schemas.getFormatMetadata(kind, function_name).then((metadata) => {

--- a/test/test_formatter.js
+++ b/test/test_formatter.js
@@ -167,10 +167,51 @@ Picture: http://example.com/security-camera.jpg`
     ['org.thingpedia.builtin.thingengine.builtin:get_date',
       {date: new Date(2018, 4, 24, 11, 4, 0) }, null,
     [ 'Today is Thursday, May 24, 2018.' ]
-    ]
+    ],
+
+    [`count(com.bing:web_search)`, {
+        count: 7,
+    }, null,
+    [ 'I found 7 results.' ]
+    ],
+
+    [`count(com.bing:web_search)`, {
+        title: 7,
+    }, null,
+    [ 'I found 7 distinct values of title.' ]
+    ],
+
+    [`max(com.google.drive:list_drive_files)`, {
+        file_size: 7,
+    }, null,
+    [ 'The maximum file size is 7.' ]
+    ],
+
+    [`min(com.google.drive:list_drive_files)`, {
+        file_size: 7,
+    }, null,
+    [ 'The minimum file size is 7.' ]
+    ],
+
+    [`avg(com.google.drive:list_drive_files)`, {
+        file_size: 7,
+    }, null,
+    [ 'The average file size is 7.' ]
+    ],
+
+    [`sum(com.google.drive:list_drive_files)`, {
+        file_size: 7,
+    }, null,
+    [ 'The total file size is 7.' ]
+    ],
 ];
 
-const formatter = new Formatter('en-US', 'America/Los_Angeles', schemaRetriever);
+const gettext = {
+    locale: 'en-US',
+    dgettext: (domain, msgid) => msgid
+};
+
+const formatter = new Formatter('en-US', 'America/Los_Angeles', schemaRetriever, gettext);
 
 function test(i) {
     console.log('Test Case #' + (i+1));

--- a/test/test_sentence_generator.js
+++ b/test/test_sentence_generator.js
@@ -232,7 +232,7 @@ async function main() {
         targetLanguage: 'thingtalk',
         thingpediaClient: _tpClient,
         turkingMode: false,
-        maxDepth: 7,
+        maxDepth: 6,
         debug: true
     };
 


### PR DESCRIPTION
The previous code would blindly throw output types of the form
"op(type)" to Thingpedia, and fail with a 404 error. Instead,
we should recognize the aggregation and do something smart about it.