### PR TITLE
lowering: support new interface of messaging

### DIFF
--- a/lib/ast/api.js
+++ b/lib/ast/api.js
@@ -523,8 +523,11 @@ function makeToken(state) {
     return state.token++;
 }
 
-function getSelf(messaging) {
-    return Ast.Value.Entity(messaging.type + '-account:' + messaging.account, 'tt:contact', "me");
+function getSelf(messaging, sendTo) {
+    if (messaging.getSelf)
+        return Ast.Value.Entity(messaging.getSelf(sendTo.value), 'tt:contact', "me");
+    else
+        return Ast.Value.Entity(messaging.type + '-account:' + messaging.account, 'tt:contact', "me");
 }
 
 function makeSendSchema(sendFrom, secondSendFrom) {
@@ -583,7 +586,7 @@ function lowerReturnAction(state, action, lastPrimitive, principal) {
     let toSendClass = makeDynamicClass([], null, receiveSchema);
 
     let sendInputs = [
-        Ast.InputParam('__principal', getSelf(state.messaging)),
+        Ast.InputParam('__principal', getSelf(state.messaging, principal)),
         Ast.InputParam('__program_id', Ast.Value.Event('program_id')),
         Ast.InputParam('__flow',  Ast.Value.Number(token)),
         Ast.InputParam('__kindChannel', Ast.Value.Event('type'))

--- a/test/test_lowerings.js
+++ b/test/test_lowerings.js
@@ -10,6 +10,7 @@
 "use strict";
 
 const Q = require('q');
+const assert = require('assert');
 
 const AppGrammar = require('../lib/grammar_api');
 const SchemaRetriever = require('../lib/schema');
@@ -112,8 +113,10 @@ const TEST_CASES = [
 ];
 
 var _mockMessaging = {
-    type: 'mock',
-    account: '12345678'
+    getSelf(sendTo) {
+        assert.strictEqual(sendTo, '1234');
+        return 'mock-account:12345678';
+    }
 };
 
 function safePrettyprint(prog) {


### PR DESCRIPTION
If messaging exposes the "getSelf" method, call it to obtain
the account to use to lower "return", passing the principal where
the program will be sent.

This allows the messaging interface to choose the correct return
address, based on who is executing the program.

This is related to https://github.com/Stanford-Mobisocial-IoT-Lab/thingengine-core/pull/42