### PR TITLE
Update partial date support

### DIFF
--- a/lib/ast/values.ts
+++ b/lib/ast/values.ts
@@ -201,9 +201,10 @@ export class DatePiece {
     month : number|null;
     day : number|null;
     time : AbsoluteTime|null;
+    future : boolean;
 
-    constructor(year : number|null, month : number|null, day : number|null, time : AbsoluteTime|null) {
-        assert((year !== null && year >= 0) || (month !== null && month > 0) || (day !== null && day > 0));
+    constructor(year : number|null, month : number|null, day : number|null, time : AbsoluteTime|null, future ?: boolean) {
+        assert((year !== null && year >= 0) || (month !== null && month > 0) || (day !== null && day > 0) || (time !== null));
         assert(year === null || month === null || day === null);
         this.year = year;
         if (year !== null && year >= 0 && year < 100) { // then assume 1950-2050
@@ -215,6 +216,7 @@ export class DatePiece {
         this.month = month;
         this.day = day;
         this.time = time;
+        this.future = future ? future : false;
     }
 
     toSource() : TokenStream {
@@ -240,7 +242,8 @@ export class DatePiece {
             return false;
         if (!(this.year === other.year
             && this.month === other.month
-            && this.day === other.day))
+            && this.day === other.day
+            && this.future === other.future))
             return false;
 
         if (this.time === other.time)
@@ -248,6 +251,7 @@ export class DatePiece {
 
         if (this.time && other.time)
             return this.time.equals(other.time);
+
         return false;
     }
 }

--- a/lib/new-syntax/parser.lr
+++ b/lib/new-syntax/parser.lr
@@ -208,7 +208,7 @@ function parseIncompleteDate($ : $runtime.ParserInterface<ParserOptions>,
         return $.error(`Too many values in Date constructor`);
     if (parts.length === 4) // 4 would be year month day hour without minute or second, which is not allowed
         return $.error(`Wrong number of values in Date constructor (must be 1, 2, 3, 5, or 6)`);
-    if (parts.length === 0 || parts.every((p) => p === null))
+    if (parts.length === 0 || (!time && parts.every((p) => p === null)))
         return $.error(`Not enough values in Date constructor`);
 
     if (parts[0] !== null) {

--- a/lib/utils/date_utils.ts
+++ b/lib/utils/date_utils.ts
@@ -78,7 +78,7 @@ function getTimeMs(hour : number, minute : number, second : number) {
     return hourMs + minMs + secMs;
 }
 
-function createDatePiece(year : number|null, month : number|null, day : number|null, time : AbsoluteTime|null, timezone: string, future ?: boolean) : Date {
+function createDatePiece(year : number|null, month : number|null, day : number|null, time : AbsoluteTime|null, timezone : string, future ?: boolean) : Date {
     let date = Temporal.Now.zonedDateTimeISO(timezone);
     //Get the next instance of the supplied values
     //Use the last blank value to get the next instance

--- a/test/test_nn_syntax.js
+++ b/test/test_nn_syntax.js
@@ -603,6 +603,10 @@ const TEST_CASES = [
      `get sunrise sunset on the 10 th at TIME_0`, { TIME_0: { hour: 5, minute: 0 } },
      `@org.thingpedia.weather.sunrise(date=new Date(, , 10, new Time(5, 0)));`],
 
+    [`@org.thingpedia.weather . sunrise ( date = new Date ( , , , TIME_0 ) ) ;`,
+    `get sunrise sunset at TIME_0`, { TIME_0: { hour: 5, minute: 0 } },
+    `@org.thingpedia.weather.sunrise(date=new Date(, , , new Time(5, 0)));`],
+
     [`@org.thingpedia.weather . sunrise ( date = new Date ( NUMBER_0 , 3 ) ) ;`,
      `get sunrise sunset on March, NUMBER_0`, { NUMBER_0: 2020 },
      `@org.thingpedia.weather.sunrise(date=new Date("2020-03-01T08:00:00.000Z"));`],


### PR DESCRIPTION
- Add future partial date so that in order to get the next instance of a date (e.g. asking for "the 9th" when it's October 10th should return November 9th).
- Support for resolving a partial date when given only time